### PR TITLE
ci: run the frontend unit suite so it actually gates PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,6 +47,17 @@ jobs:
           test -f custom_components/maintenance_supporter/frontend/maintenance-panel.js || exit 1
           test -f custom_components/maintenance_supporter/frontend/maintenance-card.js || exit 1
 
+      # Run the frontend unit suite in real Chromium. This is the gate that
+      # catches contract bugs like #69 — the ll-custom payload tripwire fires
+      # HA's real nested fire-dom-event shape and fails if the handler regresses.
+      # Without this step the ~118 web-test-runner tests never gated a PR.
+      - name: Install Playwright Chromium
+        working-directory: custom_components/maintenance_supporter/frontend-src
+        run: npx playwright install --with-deps chromium
+      - name: Frontend unit tests
+        working-directory: custom_components/maintenance_supporter/frontend-src
+        run: npm test
+
   pytest:
     runs-on: ubuntu-latest
     needs: [syntax-check, lint]


### PR DESCRIPTION
## Why

The `frontend-build` CI job only **built** the bundle — it never ran `npm test`, so the ~118 web-test-runner unit tests have not been gating PRs. That's the hole that let #69 ship: `verify-strategy.mjs` simulated the `ll-custom` event with a shape Home Assistant never produces, and no other check exercised the handler.

## What

Adds two steps to `frontend-build`: install Playwright Chromium, then `npm test`. The new `__tests__/ll-custom-payload.test.ts` tripwire (fires HA's **real** nested `fire-dom-event` shape; red-green verified) and every other frontend unit test now block merge on regression.

This is the durable answer to "how does a bug like #69 not get through" — the regression test now runs where it counts.