### PR TITLE
fix: enable the Maintenance panel by default (#69 follow-up — 404 on Open panel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Maintenance Supporter are documented in this file.
 
+## [2.10.4] - 2026-06-27
+
+### 🐛 Fixes
+
+- **The Maintenance panel is now enabled by default.** The sidebar panel (`/maintenance-supporter`) is the hub that the auto-dashboard's **"Open Maintenance panel"** button, **QR codes**, and **notifications** all link to — but it was off by default, so on a fresh install those links returned **404** (a #69 follow-up: "Open Maintenance panel does nothing"). It now defaults on. If you had previously turned it off, it stays off; you can still toggle it under the integration's options. Existing setups that never touched the setting will gain the **Maintenance** sidebar entry after updating.
+
 ## [2.10.3] - 2026-06-26
 
 ### 🐛 Fixes

--- a/custom_components/maintenance_supporter/__init__.py
+++ b/custom_components/maintenance_supporter/__init__.py
@@ -46,6 +46,7 @@ from .const import (
     CONF_OBJECT,
     CONF_PANEL_ENABLED,
     CONF_TASKS,
+    DEFAULT_PANEL_ENABLED,
     DEFAULT_WARNING_DAYS,
     DOMAIN,
     GLOBAL_UNIQUE_ID,
@@ -723,8 +724,8 @@ async def async_setup_entry(
             hass.config_entries.async_update_entry(entry, options=options)
             _LOGGER.info("Migrated advanced feature flags: %s", flags)
 
-        # Register panel if enabled in options
-        if entry.options.get(CONF_PANEL_ENABLED, False):
+        # Register panel if enabled in options (on by default — see const).
+        if entry.options.get(CONF_PANEL_ENABLED, DEFAULT_PANEL_ENABLED):
             await async_register_panel(hass)
 
         # Listen for options changes (panel toggle)
@@ -822,7 +823,7 @@ async def _async_global_options_updated(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
     """React to global options changes (panel toggle / sidebar title)."""
-    panel_enabled = entry.options.get(CONF_PANEL_ENABLED, False)
+    panel_enabled = entry.options.get(CONF_PANEL_ENABLED, DEFAULT_PANEL_ENABLED)
     if panel_enabled:
         # force=True so a changed sidebar title (CONF_PANEL_TITLE) re-registers
         # the panel; it's a no-op refresh when the title is unchanged.

--- a/custom_components/maintenance_supporter/config_flow_options_global.py
+++ b/custom_components/maintenance_supporter/config_flow_options_global.py
@@ -56,6 +56,7 @@ from .const import (
     CONF_QUIET_HOURS_START,
     CONF_SNOOZE_DURATION_HOURS,
     DEFAULT_MAX_NOTIFICATIONS_PER_DAY,
+    DEFAULT_PANEL_ENABLED,
     DEFAULT_SNOOZE_DURATION_HOURS,
     DEFAULT_WARNING_DAYS,
     MAX_PANEL_TITLE_LENGTH,
@@ -479,7 +480,7 @@ class GlobalOptionsFlow(OptionsFlow):
                     ),
                     vol.Optional(
                         CONF_PANEL_ENABLED,
-                        default=current.get(CONF_PANEL_ENABLED, False),
+                        default=current.get(CONF_PANEL_ENABLED, DEFAULT_PANEL_ENABLED),
                     ): selector.BooleanSelector(),
                     # Blank clears the override → panel falls back to the default
                     # title ("Maintenance"). suggested_value pre-fills the current

--- a/custom_components/maintenance_supporter/const.py
+++ b/custom_components/maintenance_supporter/const.py
@@ -67,6 +67,12 @@ CONF_DEFAULT_WARNING_DAYS = "default_warning_days"
 CONF_NOTIFICATIONS_ENABLED = "notifications_enabled"
 CONF_NOTIFY_SERVICE = "notify_service"
 CONF_PANEL_ENABLED = "panel_enabled"
+# v2.10.4 (#69 follow-up): the sidebar panel is the integration's hub — the
+# auto-dashboard's "Open Maintenance panel" button, QR codes, and notifications
+# all link to /maintenance-supporter. With the panel off those links 404, so it
+# now defaults ON. An explicit opt-out (panel_enabled: false in options) is
+# still honoured. Read this default everywhere instead of inlining the literal.
+DEFAULT_PANEL_ENABLED = True
 CONF_PANEL_TITLE = "panel_title"
 
 # --- Config Keys: Advanced Feature Visibility ---

--- a/custom_components/maintenance_supporter/manifest.json
+++ b/custom_components/maintenance_supporter/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/iluebbe/maintenance_supporter/issues",
   "requirements": [],
-  "version": "2.10.3"
+  "version": "2.10.4"
 }

--- a/custom_components/maintenance_supporter/websocket/dashboard.py
+++ b/custom_components/maintenance_supporter/websocket/dashboard.py
@@ -59,6 +59,7 @@ from ..const import (
     DEFAULT_ARCHIVE_ONEOFF_DAYS,
     DEFAULT_DELETE_ARCHIVED_ONEOFF_DAYS,
     DEFAULT_OBJECTS_TABLE_COLUMNS,
+    DEFAULT_PANEL_ENABLED,
     DOMAIN,
     KNOWN_OBJECT_TABLE_COLUMNS,
     MAX_PANEL_TITLE_LENGTH,
@@ -174,7 +175,7 @@ def _build_full_settings(options: Mapping[str, Any]) -> dict[str, Any]:
             "default_warning_days": options.get(CONF_DEFAULT_WARNING_DAYS, 7),
             "notifications_enabled": options.get(CONF_NOTIFICATIONS_ENABLED, False),
             "notify_service": options.get(CONF_NOTIFY_SERVICE, ""),
-            "panel_enabled": options.get(CONF_PANEL_ENABLED, False),
+            "panel_enabled": options.get(CONF_PANEL_ENABLED, DEFAULT_PANEL_ENABLED),
             "panel_title": options.get(CONF_PANEL_TITLE, ""),
         },
         "notifications": {

--- a/tests/test_panel_frontend_integration.py
+++ b/tests/test_panel_frontend_integration.py
@@ -157,6 +157,35 @@ async def test_panel_registered_when_enabled(hass: HomeAssistant) -> None:
     assert hass.data[DOMAIN].get("_panel_registered") is True
 
 
+async def test_panel_registered_by_default_when_option_absent(
+    hass: HomeAssistant,
+) -> None:
+    """Panel registers when CONF_PANEL_ENABLED is ABSENT from options — it now
+    defaults ON (v2.10.4, #69 follow-up) so the empty-state "Open panel" button,
+    QR codes, and notifications (all linking to /maintenance-supporter) don't 404.
+    """
+    entry = MockConfigEntry(
+        version=1,
+        minor_version=1,
+        domain=DOMAIN,
+        title="Maintenance Supporter",
+        data=build_global_entry_data(),
+        options={},  # no panel_enabled key -> the default (True) applies
+        source="user",
+        unique_id=GLOBAL_UNIQUE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.panel_custom.async_register_panel",
+        new_callable=AsyncMock,
+    ) as mock_register:
+        await setup_integration(hass, entry)
+        mock_register.assert_called_once()
+
+    assert hass.data[DOMAIN].get("_panel_registered") is True
+
+
 async def test_panel_and_card_registered_together(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_ws_dashboard.py
+++ b/tests/test_ws_dashboard.py
@@ -539,7 +539,7 @@ async def test_get_settings_returns_all_sections(
     # Check general defaults
     assert result["general"]["default_warning_days"] == 7
     assert result["general"]["notifications_enabled"] is False
-    assert result["general"]["panel_enabled"] is False
+    assert result["general"]["panel_enabled"] is True  # on by default since v2.10.4 (#69 follow-up)
     # Check notification defaults
     assert result["notifications"]["due_soon_enabled"] is True
     assert result["notifications"]["quiet_hours_enabled"] is True


### PR DESCRIPTION
## What

A #69 follow-up. The auto-dashboard's **"Open Maintenance panel"** button — plus **QR codes** and **notifications** — all link to `/maintenance-supporter`, but the panel was **off by default** (`panel_enabled`), so on a fresh install those links returned **404** (the "Open Maintenance panel does nothing" half of #69).

## Fix

The panel now defaults **on**. Adds a shared `DEFAULT_PANEL_ENABLED = True` constant and routes all four read-points through it (registration ×2, settings exposure, options-flow default). An explicit opt-out (`panel_enabled: false` in options) is still honored.

- New tripwire: `test_panel_registered_by_default_when_option_absent`.
- Behavior note: existing setups that never touched the setting gain the **Maintenance** sidebar entry after updating (called out in the CHANGELOG).

## Verified locally

ruff ✅ · mypy strict ✅ · full pytest **2206 passed**, coverage **98.05%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)