### PR TITLE
fix: resolve mobile_app notify service by device name, not identifier (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Maintenance Supporter are documented in this file.
 
+## [2.10.5] - 2026-06-27
+
+### 🐛 Fixes
+
+- **Per-user mobile notifications now reach the right phone.** User-targeted notifications resolved the Companion-app notify service by the device's internal identifier (a webhook UUID), so the lookup always missed and notifications silently fell back to the **global** notify service. They now resolve `notify.mobile_app_<device-name>` correctly (the slugified device name, matching how Home Assistant registers the service), including for devices renamed in HA. Thanks @SkipCool33 for the precise diagnosis (#75).
+
 ## [2.10.4] - 2026-06-27
 
 ### 🐛 Fixes

--- a/custom_components/maintenance_supporter/helpers/notification_manager.py
+++ b/custom_components/maintenance_supporter/helpers/notification_manager.py
@@ -425,30 +425,42 @@ async def _get_user_notify_services(
     4. Return list of service names
     """
     from homeassistant.helpers import device_registry as dr
+    from homeassistant.util import slugify
 
     device_reg = dr.async_get(hass)
-    services = []
+    services: list[str] = []
+    seen: set[str] = set()
 
     # Find mobile_app config entries for this user
     for entry in hass.config_entries.async_entries("mobile_app"):
         if entry.data.get("user_id") != user_id:
             continue
 
-        # Get devices linked to this config entry
-        devices = dr.async_entries_for_config_entry(device_reg, entry.entry_id)
-        for device in devices:
-            for identifier in device.identifiers:
-                if identifier[0] == "mobile_app":
-                    device_id = identifier[1]
-                    service_name = f"notify.mobile_app_{device_id}"
+        # mobile_app registers its notify service as ``notify.mobile_app_<slug>``
+        # where <slug> = slugify(device name): the legacy notify platform
+        # slugifies each target, and mobile_app's target is
+        # ``entry.data[ATTR_DEVICE_NAME]`` ("device_name"). The previous code
+        # used the device IDENTIFIER (a webhook UUID) instead, so the lookup
+        # never matched and user notifications silently fell back to the global
+        # service (#75). Use the entry's device_name (authoritative), plus the
+        # device-registry names as a safety net (older entries without
+        # device_name, or a device the user renamed).
+        candidate_names: set[str] = {entry.data.get("device_name") or ""}
+        for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
+            candidate_names.add(device.name_by_user or "")
+            candidate_names.add(device.name or "")
 
-                    if hass.services.has_service("notify", f"mobile_app_{device_id}"):
-                        services.append(service_name)
-                        _LOGGER.debug(
-                            "Found notify service %s for user %s",
-                            service_name,
-                            user_id,
-                        )
+        for name in candidate_names:
+            if not name:
+                continue
+            service = f"mobile_app_{slugify(name)}"
+            if service in seen or not hass.services.has_service("notify", service):
+                continue
+            seen.add(service)
+            services.append(f"notify.{service}")
+            _LOGGER.debug(
+                "Found notify service notify.%s for user %s", service, user_id
+            )
 
     return services
 

--- a/custom_components/maintenance_supporter/manifest.json
+++ b/custom_components/maintenance_supporter/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/iluebbe/maintenance_supporter/issues",
   "requirements": [],
-  "version": "2.10.4"
+  "version": "2.10.5"
 }

--- a/tests/test_notification_deep.py
+++ b/tests/test_notification_deep.py
@@ -466,30 +466,64 @@ async def test_user_notify_services_no_mobile_app(hass: HomeAssistant) -> None:
 
 
 async def test_user_notify_services_with_mobile_app(hass: HomeAssistant) -> None:
-    """Test user notify discovery finds mobile_app services."""
+    """User notify discovery finds mobile_app services by the slugified device name.
+
+    Regression for #75: the real service is ``notify.mobile_app_<slug(device_name)>``,
+    NOT ``mobile_app_<device_identifier>`` (a webhook UUID). Here the identifier
+    deliberately differs from the device-name slug, so the old identifier-based
+    lookup would miss it and fall back to the global service.
+    """
     from homeassistant.helpers import device_registry as dr
 
-    # Create a mobile_app config entry
+    # Create a mobile_app config entry (carries the device_name mobile_app uses).
     mobile_entry = MockConfigEntry(
         domain="mobile_app",
-        data={"user_id": "user123"},
+        data={"user_id": "user123", "device_name": "Test Phone"},
         source="user",
     )
     mobile_entry.add_to_hass(hass)
 
-    # Create a device linked to that entry
+    # Device identifier is a webhook UUID — NOT the service slug.
     device_reg = dr.async_get(hass)
     device_reg.async_get_or_create(
         config_entry_id=mobile_entry.entry_id,
-        identifiers={("mobile_app", "test_phone")},
+        identifiers={("mobile_app", "a1b2c3d4-e5f6-7890-webhook-uuid")},
         name="Test Phone",
     )
 
-    # Register the corresponding notify service
+    # The real service name is the slugified device name.
     hass.services.async_register("notify", "mobile_app_test_phone", AsyncMock())
 
     services = await _get_user_notify_services(hass, "user123")
-    assert "notify.mobile_app_test_phone" in services
+    assert services == ["notify.mobile_app_test_phone"]
+
+
+async def test_user_notify_services_renamed_device(hass: HomeAssistant) -> None:
+    """#75 safety net: a device renamed in HA (name_by_user) still resolves — the
+    mobile_app service keeps the original registration name, which lives in the
+    entry's ``device_name``."""
+    from homeassistant.helpers import device_registry as dr
+
+    mobile_entry = MockConfigEntry(
+        domain="mobile_app",
+        data={"user_id": "user123", "device_name": "Original Name"},
+        source="user",
+    )
+    mobile_entry.add_to_hass(hass)
+
+    device_reg = dr.async_get(hass)
+    device = device_reg.async_get_or_create(
+        config_entry_id=mobile_entry.entry_id,
+        identifiers={("mobile_app", "webhook-uuid-xyz")},
+        name="Original Name",
+    )
+    device_reg.async_update_device(device.id, name_by_user="My Renamed Phone")
+
+    # Service still follows the original registration name.
+    hass.services.async_register("notify", "mobile_app_original_name", AsyncMock())
+
+    services = await _get_user_notify_services(hass, "user123")
+    assert "notify.mobile_app_original_name" in services
 
 
 async def test_user_notify_services_wrong_user(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## What

Fixes #75 — per-user mobile notifications never reached the user's phone; they silently fell back to the global notify service.

## Root cause

`_get_user_notify_services` resolved the Companion-app notify service by the device's **internal identifier** (`notify.mobile_app_<webhook-uuid>`). HA registers it as `notify.mobile_app_<slug(device name)>` — its notify target is `entry.data["device_name"]`, which the legacy notify platform slugifies. So `has_service` always returned `False` → fallback to global.

## Fix

Resolve from the **device name**: authoritatively `entry.data["device_name"]`, plus the device-registry `name` / `name_by_user` as a safety net (older entries / devices renamed in HA), deduped, via HA's own `slugify`.

- Rewrote the existing discovery test so the identifier deliberately differs from the device-name slug (the gap that masked the bug) and added a renamed-device test. **Red-green verified** both fail against the old identifier lookup.

## Verified locally

ruff ✅ · mypy ✅ · full pytest **2207 passed**, coverage **98.08%**.

Thanks @SkipCool33 for the precise diagnosis (with a working fix in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)