### PR TITLE
feat: notify-service dropdown in the panel settings (v2.10.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Maintenance Supporter are documented in this file.
 
+## [2.10.7] - 2026-06-28
+
+### ✨ Notification-service dropdown in the panel too
+
+- The **Maintenance panel's** notification settings now offer the same notify-service **dropdown** that the integration's options flow gained in v2.10.6: your registered `notify.*` services (mobile apps, notify groups) are suggested as you type, so you no longer have to remember the exact slug. It stays a free-text field, so a service that registers later still works. (The generic `notify.send_message` entity-action is omitted, since our actionable reminders need the legacy services.)
+
 ## [2.10.6] - 2026-06-28
 
 ### ✨ Notification service picker + missing-service repair notice

--- a/custom_components/maintenance_supporter/frontend-src/__tests__/settings-view-notify-picker.test.ts
+++ b/custom_components/maintenance_supporter/frontend-src/__tests__/settings-view-notify-picker.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Lit component tests for the notify-service picker (datalist) in the general
+ * section of <maintenance-settings-view>.
+ *
+ * The picker lists registered `notify.*` services from `hass.services` as a
+ * <datalist> — suggestions while staying a free-text input (custom /
+ * lazily-registered values keep working), excluding the generic
+ * `send_message` entity-action. See settings-view.ts::_renderGeneral.
+ */
+
+import { expect, fixture, html } from "@open-wc/testing";
+import "../components/settings-view.js";
+import type { MaintenanceSettingsView } from "../components/settings-view";
+import {
+  DEFAULT_FEATURES,
+  DEFAULT_SETTINGS_RESPONSE,
+  createMockHass,
+} from "./_test-utils.js";
+
+async function mount(
+  services?: Record<string, Record<string, unknown>>,
+): Promise<MaintenanceSettingsView> {
+  const { hass } = createMockHass({
+    settingsResponse: {
+      ...DEFAULT_SETTINGS_RESPONSE,
+      general: {
+        ...DEFAULT_SETTINGS_RESPONSE.general,
+        notifications_enabled: true,
+        notify_service: "notify.mobile_app_phone",
+      },
+    },
+    services,
+  });
+  const el = await fixture<MaintenanceSettingsView>(html`
+    <maintenance-settings-view .hass=${hass} .features=${DEFAULT_FEATURES}></maintenance-settings-view>
+  `);
+  // _loadSettings is kicked off by updated() after first render.
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  return el;
+}
+
+describe("settings-view notify-service picker", () => {
+  it("lists registered notify services as datalist options, excluding send_message", async () => {
+    const el = await mount({
+      notify: {
+        mobile_app_phone: {}, // mobile_app direct
+        all_devices_group: {}, // a notify group
+        send_message: {}, // generic entity action — must be excluded
+      },
+    });
+
+    const list = el.shadowRoot?.querySelector<HTMLDataListElement>("#ms-notify-services");
+    expect(list, "datalist present").to.exist;
+    const values = Array.from(list!.querySelectorAll("option")).map((o) => o.value);
+    expect(values).to.include("notify.mobile_app_phone");
+    expect(values).to.include("notify.all_devices_group");
+    expect(values, "generic send_message action excluded").to.not.include("notify.send_message");
+
+    // The field stays a free-text input wired to the datalist (custom values
+    // still work for lazily-registered services).
+    const input = el.shadowRoot?.querySelector<HTMLInputElement>(
+      'input[list="ms-notify-services"]',
+    );
+    expect(input, "notify input wired to datalist").to.exist;
+    expect(input!.value).to.equal("notify.mobile_app_phone");
+  });
+
+  it("degrades to an empty datalist when no notify services are registered", async () => {
+    const el = await mount(undefined); // hass.services undefined
+
+    const list = el.shadowRoot?.querySelector<HTMLDataListElement>("#ms-notify-services");
+    expect(list, "datalist still present").to.exist;
+    expect(list!.querySelectorAll("option").length, "no options").to.equal(0);
+    // Free-text input still renders so notifications can be configured.
+    const input = el.shadowRoot?.querySelector<HTMLInputElement>(
+      'input[list="ms-notify-services"]',
+    );
+    expect(input, "notify input still present").to.exist;
+  });
+});

--- a/custom_components/maintenance_supporter/frontend-src/components/settings-view.ts
+++ b/custom_components/maintenance_supporter/frontend-src/components/settings-view.ts
@@ -377,6 +377,15 @@ export class MaintenanceSettingsView extends LitElement {
 
   private _renderGeneral(L: string) {
     const g = this._settings!.general;
+    // Suggestible notify services for the picker below — read live from the
+    // frontend service registry (mobile_app devices, notify groups, …), minus
+    // the generic send_message entity-action. The <datalist> keeps this a
+    // free-text input (custom/lazily-registered values still work) while
+    // offering the real service names so users don't have to guess the slug.
+    const notifyServices = Object.keys(this.hass?.services?.notify ?? {})
+      .filter((n) => n !== "send_message")
+      .map((n) => `notify.${n}`)
+      .sort();
     const b = this._settings!.budget;
     return html`
       <div class="settings-section">
@@ -417,8 +426,11 @@ export class MaintenanceSettingsView extends LitElement {
         ${g.notifications_enabled ? html`
           <label class="setting-row">
             <span class="setting-label">${t("settings_notify_service", L)}</span>
-            <input type="text" .value=${g.notify_service}
+            <input type="text" list="ms-notify-services" .value=${g.notify_service}
               @change=${(e: Event) => this._updateSetting("notify_service", (e.target as HTMLInputElement).value.trim())} />
+            <datalist id="ms-notify-services">
+              ${notifyServices.map((s) => html`<option value=${s}></option>`)}
+            </datalist>
           </label>
           <div class="setting-row">
             <span class="setting-label">${t("test_notification", L)}</span>

--- a/custom_components/maintenance_supporter/frontend/maintenance-panel.js
+++ b/custom_components/maintenance_supporter/frontend/maintenance-panel.js
@@ -4017,24 +4017,24 @@ ${p?`<div class="sub">${p}</div>`:""}
           </label>
         `)}
       </div>
-    `}_toggleColumn(e,t){let i=new Set(Ee(this._settings.objects_table_columns));t?i.add(e):i.delete(e);let a=he.filter(l=>l.required||i.has(l.key)).map(l=>l.key);this._updateSetting("objects_table_columns",a)}_renderGeneral(e){let t=this._settings.general,i=this._settings.budget;return n`
+    `}_toggleColumn(e,t){let i=new Set(Ee(this._settings.objects_table_columns));t?i.add(e):i.delete(e);let a=he.filter(l=>l.required||i.has(l.key)).map(l=>l.key);this._updateSetting("objects_table_columns",a)}_renderGeneral(e){let t=this._settings.general,i=Object.keys(this.hass?.services?.notify??{}).filter(l=>l!=="send_message").map(l=>`notify.${l}`).sort(),a=this._settings.budget;return n`
       <div class="settings-section">
         <h3>${s("settings_general",e)}</h3>
         <label class="setting-row">
           <span class="setting-label">${s("settings_default_warning",e)}</span>
           <input type="number" min="1" max="365" .value=${String(t.default_warning_days)}
-            @change=${a=>{let l=parseInt(a.target.value,10);l>=1&&l<=365&&this._updateSetting("default_warning_days",l)}} />
+            @change=${l=>{let c=parseInt(l.target.value,10);c>=1&&c<=365&&this._updateSetting("default_warning_days",c)}} />
         </label>
         <label class="setting-row">
           <span class="setting-label">${s("settings_currency",e)}</span>
-          <select @change=${a=>this._updateSetting("budget_currency",a.target.value)}>
-            ${ts.map(a=>n`<option value=${a} ?selected=${i.currency===a}>${a}</option>`)}
+          <select @change=${l=>this._updateSetting("budget_currency",l.target.value)}>
+            ${ts.map(l=>n`<option value=${l} ?selected=${a.currency===l}>${l}</option>`)}
           </select>
         </label>
         <label class="setting-row">
           <span class="setting-label">${s("settings_panel_enabled",e)}</span>
           <input type="checkbox" .checked=${t.panel_enabled}
-            @change=${a=>this._updateSetting("panel_enabled",a.target.checked)} />
+            @change=${l=>this._updateSetting("panel_enabled",l.target.checked)} />
         </label>
         ${t.panel_enabled?n`
           <label class="setting-row">
@@ -4042,19 +4042,22 @@ ${p?`<div class="sub">${p}</div>`:""}
             <input type="text" .value=${t.panel_title??""}
               placeholder="Maintenance"
               maxlength="50"
-              @change=${a=>this._updateSetting("panel_title",a.target.value.trim())} />
+              @change=${l=>this._updateSetting("panel_title",l.target.value.trim())} />
           </label>
         `:""}
         <label class="setting-row">
           <span class="setting-label">${s("settings_notifications",e)}</span>
           <input type="checkbox" .checked=${t.notifications_enabled}
-            @change=${a=>this._updateSetting("notifications_enabled",a.target.checked)} />
+            @change=${l=>this._updateSetting("notifications_enabled",l.target.checked)} />
         </label>
         ${t.notifications_enabled?n`
           <label class="setting-row">
             <span class="setting-label">${s("settings_notify_service",e)}</span>
-            <input type="text" .value=${t.notify_service}
-              @change=${a=>this._updateSetting("notify_service",a.target.value.trim())} />
+            <input type="text" list="ms-notify-services" .value=${t.notify_service}
+              @change=${l=>this._updateSetting("notify_service",l.target.value.trim())} />
+            <datalist id="ms-notify-services">
+              ${i.map(l=>n`<option value=${l}></option>`)}
+            </datalist>
           </label>
           <div class="setting-row">
             <span class="setting-label">${s("test_notification",e)}</span>

--- a/custom_components/maintenance_supporter/manifest.json
+++ b/custom_components/maintenance_supporter/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/iluebbe/maintenance_supporter/issues",
   "requirements": [],
-  "version": "2.10.6"
+  "version": "2.10.7"
 }


### PR DESCRIPTION
Follow-up to #78 / v2.10.6: that release added the notify-service picker to the integration's **options flow**. This mirrors it in the **custom panel's** notification settings, so panel users get the same dropdown.

## What
- `settings-view.ts`: the notify-service `<input>` now has a `<datalist>` of registered `notify.*` services read live from `hass.services` (mobile_app devices + notify groups), excluding the generic `send_message` entity-action. It stays a free-text field (custom_value equivalent), so lazily-registered services still work.
- **No backend/WS change** — the frontend service registry already exposes the list client-side.
- Rebuilt `maintenance-panel.js`.

## Why send_message is excluded
The notify-entity model carries only message+title; our actionable reminders (Complete/Skip/Snooze, tag, deep link) need the legacy `notify.*` services. Same rationale as v2.10.6.

## Tests
- 2 new Lit tests: the datalist lists the registered services and excludes `send_message`; it degrades to an empty list (free-text still works) when none are registered.
- Frontend suite: **120 passed** (was 118); esbuild build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)