### PR TITLE
feat: notify-service dropdown in the setup wizard (v2.10.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Maintenance Supporter are documented in this file.
 
+## [2.10.8] - 2026-06-28
+
+### ✨ Notification-service dropdown in the setup wizard too
+
+- The notify-service picker — added to the integration's options flow in v2.10.6 and the panel in v2.10.7 — is now also in the **initial setup wizard**, so choosing your `notify.*` service is consistent in all three places it can be set. As before, it stays free-text so a service that registers later still works.
+
 ## [2.10.7] - 2026-06-28
 
 ### ✨ Notification-service dropdown in the panel too

--- a/custom_components/maintenance_supporter/config_flow.py
+++ b/custom_components/maintenance_supporter/config_flow.py
@@ -133,6 +133,17 @@ class MaintenanceSupporterConfigFlow(TriggerConfigMixin, ConfigFlow, domain=DOMA
                     },
                 )
 
+        # Offer registered notify.* services as a dropdown (mobile_app devices,
+        # notify groups, …), excluding the generic send_message entity-action.
+        # custom_value keeps it free-text so a not-yet-registered service still
+        # works — the format-only validation above never blocks on existence.
+        # Matches the picker in the options flow + panel.
+        notify_services = sorted(
+            f"notify.{name}"
+            for name in self.hass.services.async_services().get("notify", {})
+            if name != "send_message"
+        )
+
         return self.async_show_form(
             step_id="global_setup",
             data_schema=vol.Schema(
@@ -149,9 +160,11 @@ class MaintenanceSupporterConfigFlow(TriggerConfigMixin, ConfigFlow, domain=DOMA
                     ): selector.BooleanSelector(),
                     vol.Optional(
                         CONF_NOTIFY_SERVICE, default=""
-                    ): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.TEXT
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=notify_services,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            custom_value=True,
                         )
                     ),
                 }

--- a/custom_components/maintenance_supporter/manifest.json
+++ b/custom_components/maintenance_supporter/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/iluebbe/maintenance_supporter/issues",
   "requirements": [],
-  "version": "2.10.7"
+  "version": "2.10.8"
 }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,6 +18,7 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import selector
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -127,6 +128,31 @@ async def test_global_setup_creates_entry(hass: HomeAssistant) -> None:
     assert result["data"][CONF_DEFAULT_WARNING_DAYS] == 10
     assert result["data"][CONF_NOTIFICATIONS_ENABLED] is True
     assert result["data"][CONF_NOTIFY_SERVICE] == "notify.mobile"
+
+
+async def test_global_setup_notify_dropdown(hass: HomeAssistant) -> None:
+    """The setup wizard offers registered notify.* services as a dropdown
+    (mobile_app + groups), excludes the generic send_message action, and keeps
+    custom_value so a not-yet-registered service can still be typed."""
+    hass.services.async_register("notify", "mobile_app_phone", lambda call: None)
+    hass.services.async_register("notify", "all_devices_group", lambda call: None)
+    hass.services.async_register("notify", "send_message", lambda call: None)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "global_setup"
+    schema = result["data_schema"].schema
+    notify_field = next(
+        v for k, v in schema.items()
+        if getattr(k, "schema", k) == CONF_NOTIFY_SERVICE
+    )
+    assert isinstance(notify_field, selector.SelectSelector)
+    options = notify_field.config["options"]
+    assert "notify.mobile_app_phone" in options
+    assert "notify.all_devices_group" in options
+    assert "notify.send_message" not in options
+    assert notify_field.config["custom_value"] is True
 
 
 async def test_global_setup_default_values(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Completes the notify-service picker across **all three** surfaces where the service can be set:

| Surface | Release |
|---|---|
| Options flow (`config_flow_options_global.py`) | v2.10.6 |
| Custom panel (`settings-view.ts`) | v2.10.7 |
| **Initial setup wizard** (`config_flow.py::async_step_global_setup`) | **this PR** |

## What
- The setup wizard's `CONF_NOTIFY_SERVICE` field becomes a `SelectSelector` listing registered `notify.*` services (mobile_app devices + notify groups), excluding the generic `send_message` entity-action, with `custom_value` so a not-yet-registered service still works. Validation stays format-only (never blocks on existence).

## Tests / gates
- New `test_global_setup_notify_dropdown` asserts the dropdown options + `custom_value`; existing setup-flow tests still pass (custom_value accepts their free-text values).
- Verified in Docker: full suite **2218 passed**, coverage **98.07%**; `ruff` + `mypy --strict` clean; clean live-load of the integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)