### PR TITLE
Fix battery type for low-only Battery Notes devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Maintenance Supporter are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Battery Fleet now preserves Battery Notes type metadata for devices that
+  expose only a low-battery binary sensor, instead of showing `UNKNOWN` (#121).
+
 ## [2.46.0] - 2026-07-31
 
 ### ✨ Added

--- a/custom_components/maintenance_supporter/helpers/battery_fleet.py
+++ b/custom_components/maintenance_supporter/helpers/battery_fleet.py
@@ -6,11 +6,11 @@ sensor into ONE fleet view: which batteries are low now, grouped by battery
 type (so you know *what to buy*), plus a simple deterministic forecast of what
 will be needed soon (so you can order in time).
 
-Battery Notes exposes everything we need as ATTRIBUTES on the single
-``battery_plus`` sensor (device_class ``battery``): ``battery_type``,
-``battery_quantity``, ``battery_low``, ``battery_low_threshold``,
-``battery_last_replaced``. We read that one sensor kind — no dependency on the
-(optional, often-disabled) battery-low binary.
+Battery Notes exposes everything we need as attributes on a ``battery_plus``
+entity (device_class ``battery``): ``battery_type``, ``battery_quantity``,
+``battery_low``, ``battery_low_threshold``, and ``battery_last_replaced``. Most
+devices expose a percentage sensor, while low-only devices expose a binary
+sensor with the same metadata.
 
 The pure builder ``build_overview`` takes plain battery dicts + an injected
 ``today`` so the forecast is unit-testable with synthetic dates; ``read_batteries``
@@ -22,6 +22,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import date, timedelta
+from itertools import chain
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -280,7 +281,7 @@ def _is_self_charging(hass: HomeAssistant, device_id: str | None) -> bool:
 def read_batteries(hass: HomeAssistant) -> list[Battery]:
     """Read the battery fleet from HA state — Battery Notes AND native.
 
-    * **Battery Notes** ``battery_plus`` sensors (device_class ``battery`` + a
+    * **Battery Notes** ``battery_plus`` entities (device_class ``battery`` + a
       ``battery_type`` attribute) give the rich view: type, quantity, low,
       last-replaced. When the source goes offline the sensor reads
       unavailable/unknown but RETAINS its last-known ``battery_low`` — so a
@@ -311,19 +312,25 @@ def read_batteries(hass: HomeAssistant) -> list[Battery]:
     covered_devices: set[str] = set()
 
     # ── Pass 1: Battery Notes battery_plus ──────────────────────────────────
-    for state in hass.states.async_all("sensor"):
+    states = chain(hass.states.async_all("sensor"), hass.states.async_all("binary_sensor"))
+    for state in states:
         attrs = state.attributes
         if attrs.get("device_class") != "battery" or "battery_type" not in attrs:
             continue
+        is_binary = state.entity_id.startswith("binary_sensor.")
         level = _level_of(state.state)
-        available = state.state not in _NO_READING and level is not None
+        available = state.state not in _NO_READING and (is_binary or level is not None)
         # B2 (roadmap 2026-07-22 audit): ONE low floor across both passes.
         # Battery Notes' own threshold (default 10 %) still counts via its
         # battery_low flag, but the fleet-wide NATIVE_LOW_PERCENT floor is
         # OR-ed in — a CR2032 at 11.5 % was "healthy" here while the same
         # level counted low in the native pass. A HIGHER Battery Notes
         # threshold (e.g. 30 %) still wins through battery_low.
-        low = bool(attrs.get("battery_low")) or (level is not None and level <= NATIVE_LOW_PERCENT)
+        low = (
+            bool(attrs.get("battery_low"))
+            or (is_binary and str(state.state).lower() in ("on", "true", "1"))
+            or (level is not None and level <= NATIVE_LOW_PERCENT)
+        )
         last_replaced = _parse_last_replaced(attrs.get("battery_last_replaced"))
         # B1 (roadmap 2026-07-22 audit): a forecast-only note — no level
         # sensor, so the state reads unknown forever — must SURVIVE when it
@@ -446,7 +453,8 @@ def read_batteries(hass: HomeAssistant) -> list[Battery]:
 
 def has_battery_notes(hass: HomeAssistant) -> bool:
     """Whether the Battery Notes integration is present (any battery_plus)."""
-    for state in hass.states.async_all("sensor"):
+    states = chain(hass.states.async_all("sensor"), hass.states.async_all("binary_sensor"))
+    for state in states:
         a = state.attributes
         if a.get("device_class") == "battery" and "battery_type" in a:
             return True

--- a/tests/test_battery_fleet.py
+++ b/tests/test_battery_fleet.py
@@ -112,6 +112,59 @@ async def test_native_battery_degraded_pickup(hass):
     assert phone.low is False and phone.level == 55.0
 
 
+async def test_battery_notes_low_binary_preserves_type(hass):
+    """A low-only Battery Notes entity should enrich its native battery sibling."""
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(domain="test", data={})
+    entry.add_to_hass(hass)
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("test", "level_lock")},
+        name="Back Door Lock",
+    )
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "binary_sensor",
+        "matter",
+        "level_lock_battery",
+        suggested_object_id="level_lock_matter_battery",
+        device_id=device.id,
+    )
+    ent_reg.async_get_or_create(
+        "binary_sensor",
+        "battery_notes",
+        "level_lock_battery_plus_low",
+        suggested_object_id="level_lock_matter_battery_plus_low",
+        device_id=device.id,
+    )
+    hass.states.async_set(
+        "binary_sensor.level_lock_matter_battery",
+        "off",
+        {"device_class": "battery", "friendly_name": "Back Door Lock Battery"},
+    )
+    hass.states.async_set(
+        "binary_sensor.level_lock_matter_battery_plus_low",
+        "off",
+        {
+            "device_class": "battery",
+            "battery_low": False,
+            "battery_quantity": 1,
+            "battery_type": "Lithium 3-volt CR2",
+            "device_name": "Back Door Lock",
+        },
+    )
+
+    bats = read_batteries(hass)
+    assert len(bats) == 1
+    assert bats[0].source == "battery_notes"
+    assert bats[0].battery_type == "Lithium 3-volt CR2"
+    assert bats[0].level is None and bats[0].low is False and bats[0].available is True
+    assert has_battery_notes(hass) is True
+
+
 async def test_native_low_binary_wins_over_percent(hass):
     # A battery-low binary present → it decides low, not the % heuristic.
     hass.states.async_set("binary_sensor.door_battery_low", "on", {"device_class": "battery"})


### PR DESCRIPTION
## Summary

- Read Battery Notes metadata from both percentage sensors and low-battery binary sensors.
- Treat an available binary state as a valid low-only battery reading and preserve its type and quantity metadata.
- Prevent the same device from falling back to a native `Unknown` battery row.
- Add regression coverage for a Matter lock with a Battery Notes low-only entity.

Closes #121.

## Type of change

- [x] Bug fix (`fix:` commit, behavior change, no new feature)
- [ ] New feature (`feat:` commit, additive)
- [ ] Refactor (no behavior change)
- [ ] Tests / docs / CI only
- [ ] Translation (panel or config flow strings)

## Testing

- [ ] `pytest tests/` - the current Windows host does not have the Python 3.14/Home Assistant test image
- [x] Ruff 0.15.22 check across `custom_components/maintenance_supporter/` and `tests/`
- [x] Python 3.12 syntax compilation for the changed modules
- [x] Focused stubbed Home Assistant harness covering both `off` and `on` binary states
- [x] `git diff --check`

## Notes for reviewer

The focused harness asserts one Battery Notes row, the reported CR2 type, no percentage level, correct availability, and correct low state for both binary values. The full Home Assistant suite is intentionally left to CI because this repository now tests against Python 3.14 and the newest Home Assistant package.

AI assistance was used to trace the two-pass battery aggregation and prepare the focused fix and regression test. I reviewed the final diff and ran the validation listed above.